### PR TITLE
Implemented reactive consumer.

### DIFF
--- a/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/MessageConsumerKafkaImpl.java
+++ b/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/MessageConsumerKafkaImpl.java
@@ -96,7 +96,7 @@ public class MessageConsumerKafkaImpl implements CommonMessageConsumer {
     try {
         kafkaMessageHandler
                 .apply(new KafkaMessage(EventuateBinaryMessageEncoding.bytesToString(message.getPayload())))
-                .whenComplete((unused, throwable) -> callback.accept(null, throwable));
+                .whenComplete(callback);
     } catch (Throwable e) {
       callback.accept(null, e);
       throw e;

--- a/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/MessageConsumerKafkaImpl.java
+++ b/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/MessageConsumerKafkaImpl.java
@@ -8,12 +8,15 @@ import io.eventuate.messaging.kafka.common.EventuateBinaryMessageEncoding;
 import io.eventuate.messaging.kafka.common.EventuateKafkaMultiMessageConverter;
 import io.eventuate.messaging.kafka.common.EventuateKafkaMultiMessage;
 import io.eventuate.messaging.partitionmanagement.CommonMessageConsumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 public class MessageConsumerKafkaImpl implements CommonMessageConsumer {
 
@@ -36,12 +39,23 @@ public class MessageConsumerKafkaImpl implements CommonMessageConsumer {
   }
 
   public KafkaSubscription subscribe(String subscriberId, Set<String> channels, KafkaMessageHandler handler) {
+    return subscribeWithReactiveHandler(subscriberId, channels, kafkaMessage -> {
+      handler.accept(kafkaMessage);
+      return CompletableFuture.completedFuture(null);
+    });
+  }
+
+  public KafkaSubscription subscribeWithReactiveHandler(String subscriberId, Set<String> channels, ReactiveKafkaMessageHandler handler) {
 
     SwimlaneBasedDispatcher swimlaneBasedDispatcher = new SwimlaneBasedDispatcher(subscriberId, Executors.newCachedThreadPool());
 
-    EventuateKafkaConsumerMessageHandler kcHandler = (record, callback) -> swimlaneBasedDispatcher.dispatch(new RawKafkaMessage(record.value()),
-            record.partition(),
-            message -> handle(message, callback, handler));
+    EventuateKafkaConsumerMessageHandler kcHandler = (record, callback) -> {
+      if (eventuateKafkaMultiMessageConverter.isMultiMessage(record.value())) {
+        return handleBatch(record, swimlaneBasedDispatcher, callback, handler);
+      } else {
+        return swimlaneBasedDispatcher.dispatch(new RawKafkaMessage(record.value()), record.partition(), message -> handle(message, callback, handler));
+      }
+    };
 
     EventuateKafkaConsumer kc = new EventuateKafkaConsumer(subscriberId,
             kcHandler,
@@ -60,20 +74,35 @@ public class MessageConsumerKafkaImpl implements CommonMessageConsumer {
     });
   }
 
-  public void handle(RawKafkaMessage message, BiConsumer<Void, Throwable> callback, KafkaMessageHandler kafkaMessageHandler) {
+  private SwimlaneDispatcherBacklog handleBatch(ConsumerRecord<String, byte[]> record,
+                                                SwimlaneBasedDispatcher swimlaneBasedDispatcher,
+                                                BiConsumer<Void, Throwable> callback,
+                                                ReactiveKafkaMessageHandler handler) {
+    return eventuateKafkaMultiMessageConverter
+            .convertBytesToMessages(record.value())
+            .getMessages()
+            .stream()
+            .map(EventuateKafkaMultiMessage::getValue)
+            .map(KafkaMessage::new)
+            .map(kafkaMessage ->
+                    swimlaneBasedDispatcher.dispatch(new RawKafkaMessage(record.value()), record.partition(), message -> handle(message, callback, handler)))
+            .collect(Collectors.toList()) // it is not possible to use "findAny()" now, because streams are lazy and only one message will be processed
+            .stream()
+            .findAny()
+            .get();
+  }
+
+  private void handle(RawKafkaMessage message, BiConsumer<Void, Throwable> callback, ReactiveKafkaMessageHandler kafkaMessageHandler) {
     try {
-      if (eventuateKafkaMultiMessageConverter.isMultiMessage(message.getPayload())) {
-        eventuateKafkaMultiMessageConverter
-                .convertBytesToMessages(message.getPayload())
-                .getMessages()
-                .stream()
-                .map(EventuateKafkaMultiMessage::getValue)
-                .map(KafkaMessage::new)
-                .forEach(kafkaMessageHandler);
-      } else {
-        kafkaMessageHandler.accept(new KafkaMessage(EventuateBinaryMessageEncoding.bytesToString(message.getPayload())));
-      }
-      callback.accept(null, null);
+        kafkaMessageHandler
+                .apply(new KafkaMessage(EventuateBinaryMessageEncoding.bytesToString(message.getPayload())))
+                .thenApply(unused -> {
+                  callback.accept(null, null);
+                  return null;
+                }).exceptionally(throwable -> {
+                  callback.accept(null, throwable);
+                  return null;
+                });
     } catch (Throwable e) {
       callback.accept(null, e);
       throw e;

--- a/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/MessageConsumerKafkaImpl.java
+++ b/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/MessageConsumerKafkaImpl.java
@@ -96,13 +96,7 @@ public class MessageConsumerKafkaImpl implements CommonMessageConsumer {
     try {
         kafkaMessageHandler
                 .apply(new KafkaMessage(EventuateBinaryMessageEncoding.bytesToString(message.getPayload())))
-                .thenApply(unused -> {
-                  callback.accept(null, null);
-                  return null;
-                }).exceptionally(throwable -> {
-                  callback.accept(null, throwable);
-                  return null;
-                });
+                .whenComplete((unused, throwable) -> callback.accept(null, throwable));
     } catch (Throwable e) {
       callback.accept(null, e);
       throw e;

--- a/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/ReactiveKafkaMessageHandler.java
+++ b/eventuate-messaging-kafka-consumer/src/main/java/io/eventuate/messaging/kafka/consumer/ReactiveKafkaMessageHandler.java
@@ -1,0 +1,8 @@
+package io.eventuate.messaging.kafka.consumer;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+public interface ReactiveKafkaMessageHandler extends Function<KafkaMessage, CompletableFuture<Void>> {
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ eventuateMessagingPartitionManagementVersion=0.10.0.RELEASE
 
 eventuatePluginsGradleVersion=0.8.0.RELEASE
 
-version=0.14.0-SNAPSHOT
+version=0.15.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ springBootVersion=2.1.1.RELEASE
 micronautVersion=2.4.1
 
 eventuateUtilVersion=0.10.0.RELEASE
-eventuateMessagingPartitionManagementVersion=0.10.0.RELEASE
+eventuateMessagingPartitionManagementVersion=0.11.0.BUILD-SNAPSHOT
 
 eventuatePluginsGradleVersion=0.8.0.RELEASE
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ springBootVersion=2.1.1.RELEASE
 
 micronautVersion=2.4.1
 
-eventuateUtilVersion=0.10.0.RELEASE
+eventuateUtilVersion=0.14.0.BUILD-SNAPSHOT
 eventuateMessagingPartitionManagementVersion=0.11.0.BUILD-SNAPSHOT
 
 eventuatePluginsGradleVersion=0.8.0.RELEASE


### PR DESCRIPTION
I made it a little bit different than you said.

I think, I simplified approach by keeping biconsumer here: https://github.com/eventuate-foundation/eventuate-messaging-kafka/blob/b7b618dff09401cf12a51b7b59dd4de0d2771e2d/eventuate-messaging-kafka-basic-consumer/src/main/java/io/eventuate/messaging/kafka/basic/consumer/EventuateKafkaConsumerMessageHandler.java#L9


Especially because there is batch processing and is much easier to handle it with callbacks than with multiple futures.


